### PR TITLE
[feat]: Added volume controls

### DIFF
--- a/components/ButtonsOverlay.vue
+++ b/components/ButtonsOverlay.vue
@@ -71,12 +71,12 @@
 
 	.toggleNotiBtn {
 		position: fixed;
-		top: 10px;
+		top: 15px;
 		right: 20px;
 	}
 	.fullscreen-btn {
 		position: fixed;
-		top: 10px;
+		top: 15px;
 		right: 70px;
 		transition: right 0.3s ease-in-out;
 	}
@@ -85,7 +85,7 @@
 	}
 	.notiCount {
 		position: fixed;
-		top: 15px;
+		top: 20px;
 		right: 40px;
 		display: flex;
 		justify-content: center;
@@ -101,7 +101,7 @@
 	}
 	.volumePanel {
 		position: fixed;
-		top: 10px;
+		top: 15px;
 		right: 120px;
 		transition: right 0.3s ease-in-out;
 	}

--- a/components/ButtonsOverlay.vue
+++ b/components/ButtonsOverlay.vue
@@ -13,6 +13,14 @@
 			@click="globalStore.handleMainMenu"
 		>
 		</v-btn>
+		<div
+		:class="
+				globalStore.ENABLE_NOTIFICATIONS
+					? 'volumePanel'
+					: 'volumePanel volumePanel-right'
+			">
+			<VolumePanel />
+		</div>
 		<v-btn
 			:icon="!globalStore.isFullscreen ? 'mdi-fullscreen' : 'mdi-fullscreen-exit'"
 			:class="
@@ -90,5 +98,14 @@
 		pointer-events: none;
 		z-index: 999;
 		background-color: #ef5350;
+	}
+	.volumePanel {
+		position: fixed;
+		top: 10px;
+		right: 120px;
+		transition: right 0.3s ease-in-out;
+	}
+	.volumePanel-right {
+		right: 70px;
 	}
 </style>

--- a/components/EmbedTwitch.vue
+++ b/components/EmbedTwitch.vue
@@ -35,9 +35,10 @@
 </script>
 
 <template>
-	<div :id="twitchEmbedID" class="twitch-embed">
+	<div class="twitch-embed">
 		<iframe
 			:src="iframeSrc"
+			:id="twitchEmbedID"
 			frameborder="0"
 			allowfullscreen="true"
 			scrolling="no"

--- a/components/EmbedsList.vue
+++ b/components/EmbedsList.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 	const globalStore = useGlobalStateStore();
+  const userSettings = useSettingStore();
 
 	const expandEmbed = (streamer: string) => {
 		// console.log(streamer);
@@ -226,6 +227,11 @@
 			transform: translate(-50%, -50%);
 			max-width: unset !important;
 		}
+    .expanded-embed .close-btn,
+    .expanded-embed .expand-btn,
+    .expanded-embed .drag-btn {
+      top: 50px;
+    }
 	}
   
 	@media (max-width: 1280px) {

--- a/components/IndexComponent.vue
+++ b/components/IndexComponent.vue
@@ -152,12 +152,7 @@
 		if (!globalStore.ENABLE_AUTO_REMOVE_STREAM) return;
 
 		offlineStreamers.forEach((streamer) => {
-			globalStore.removeEmbed(streamer.user_name);
-			if (streamer.user_name === globalStore.expandedEmbed) {
-				globalStore.isExpand = false;
-				globalStore.expandedEmbed = "";
-			}
-			console.log("Removing streamer: " + streamer.user_name);
+			globalStore.removeEmbed(streamer.user_login);
 		});
 	});
 

--- a/components/IndexComponent.vue
+++ b/components/IndexComponent.vue
@@ -169,6 +169,9 @@
 				if (event.key === 'n') { // N for notifications
 					globalStore.toggleNoti()
 				}
+				if (event.key === 'm') { // N for notifications
+					userSettings.Muted = !userSettings.Muted
+				}
 			}
 		}
 	})

--- a/components/VolumePanel.vue
+++ b/components/VolumePanel.vue
@@ -37,9 +37,10 @@
       @mouseleave="handleMouseLeave">
 		<v-expand-x-transition>
 			<v-card
-      class="volumePanel"
+      class="volumePanel pl-2"
       v-if="showVolumePanel && !userSettings.Muted"
-      variant="text"
+      variant="flat"
+      color="#121212"
       >
         <v-btn
         icon="mdi-theater"
@@ -47,7 +48,7 @@
         :color="userSettings.TheatreAudio ? 'deep-purple-darken-1' : 'grey-lighten-5'"
         :variant="userSettings.TheatreAudio ? 'flat' : 'plain'"
         @click="userSettings.TheatreAudio = !userSettings.TheatreAudio"
-        class="mr-2"
+        class="mr-1 ml-1"
         title="Theatre Mode Audio Enables Audio Only For Expanded Stream"
         >
 
@@ -58,7 +59,7 @@
           max="1"
           min="0"
           step=".01"
-          class="volumeSlider ml-4 mr-3"
+          class="volumeSlider pl-3 pr-3"
         ></v-slider>
 			</v-card>
 		</v-expand-x-transition>
@@ -78,16 +79,17 @@
 		display: flex;
 	}
   .volumePanel {
-    height: 50px;
-    width: 300px;
+    transform: translateY(-5px);
+    height: 60px;
     display: flex;
     align-items: center;
     justify-content: flex-end;
     position: relative;
     overflow: visible;
+    border-radius: 10px !important;
     /* outline: 2px solid red; */
   }
   .volumeSlider {
-    max-width: 150px;
+    width: 150px;
   }
 </style>

--- a/components/VolumePanel.vue
+++ b/components/VolumePanel.vue
@@ -3,7 +3,7 @@
 	const userSettings = useSettingStore();
 
 	const toggleMute = (event: MouseEvent) => {
-		globalStore.muted = !globalStore.muted;
+		userSettings.Muted = !userSettings.Muted;
 	};
 
   const showVolumePanel = ref(false);
@@ -14,10 +14,21 @@
   };
 
   const handleMouseLeave = () => {
-    setTimeout(()=>{
+    setTimeout(() => {
       showVolumePanel.value = false;
     }, 200)
   };
+
+  const muted = ref(false);
+  onMounted(() => {
+    if (userSettings.Muted) {
+      muted.value = true;
+    }
+  });
+
+  watch(() => userSettings.Muted, (newVal) => {
+    muted.value = newVal;
+  });
 </script>
 
 <template>
@@ -27,7 +38,7 @@
 		<v-expand-x-transition>
 			<v-card
       class="volumePanel"
-      v-if="showVolumePanel && !globalStore.muted"
+      v-if="showVolumePanel && !userSettings.Muted"
       variant="text"
       >
         <v-btn
@@ -52,7 +63,7 @@
 			</v-card>
 		</v-expand-x-transition>
 		<v-btn
-			:icon="globalStore.muted ? 'mdi-volume-off' : 'mdi-volume-high'"
+			:icon="muted ? 'mdi-volume-off' : 'mdi-volume-high'"
 			variant="plain"
 			color="grey-lighten-5"
 			class="volumeBtn"

--- a/components/VolumePanel.vue
+++ b/components/VolumePanel.vue
@@ -1,0 +1,82 @@
+<script lang="ts" setup>
+	const globalStore = useGlobalStateStore();
+	const userSettings = useSettingStore();
+
+	const toggleMute = (event: MouseEvent) => {
+		globalStore.muted = !globalStore.muted;
+	};
+
+  const showVolumePanel = ref(false);
+
+  const handleMouseEnter = () => {
+    if (showVolumePanel.value) return;
+    showVolumePanel.value = true;
+  };
+
+  const handleMouseLeave = () => {
+    setTimeout(()=>{
+      showVolumePanel.value = false;
+    }, 200)
+  };
+</script>
+
+<template>
+	<div class="volumeContainer"
+      @mouseover="handleMouseEnter"
+      @mouseleave="handleMouseLeave">
+		<v-expand-x-transition>
+			<v-card
+      class="volumePanel"
+      v-if="showVolumePanel && !globalStore.muted"
+      variant="text"
+      >
+        <v-btn
+        icon="mdi-theater"
+        size="small"
+        :color="userSettings.TheatreAudio ? 'deep-purple-darken-1' : 'grey-lighten-5'"
+        :variant="userSettings.TheatreAudio ? 'flat' : 'plain'"
+        @click="userSettings.TheatreAudio = !userSettings.TheatreAudio"
+        class="mr-2"
+        title="Theatre Mode Audio Enables Audio Only For Expanded Stream"
+        >
+
+        </v-btn>
+        <v-slider
+          v-model="userSettings.Volume"
+          color="grey-lighten-5"
+          max="1"
+          min="0"
+          step=".01"
+          class="volumeSlider ml-4 mr-3"
+        ></v-slider>
+			</v-card>
+		</v-expand-x-transition>
+		<v-btn
+			:icon="globalStore.muted ? 'mdi-volume-off' : 'mdi-volume-high'"
+			variant="plain"
+			color="grey-lighten-5"
+			class="volumeBtn"
+			@click="toggleMute"
+		>
+		</v-btn>
+	</div>
+</template>
+
+<style scoped>
+	.volumeContainer {
+		display: flex;
+	}
+  .volumePanel {
+    height: 50px;
+    width: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    position: relative;
+    overflow: visible;
+    /* outline: 2px solid red; */
+  }
+  .volumeSlider {
+    max-width: 150px;
+  }
+</style>

--- a/composables/useSettingStore.ts
+++ b/composables/useSettingStore.ts
@@ -13,7 +13,7 @@ export default defineStore({
     },
     Volume: 1,
     Muted: false,
-    TheatreAudio: false,
+    TheatreAudio: true,
   }),
   actions: {
     // Action to update octoData with a new array of strings

--- a/composables/useSettingStore.ts
+++ b/composables/useSettingStore.ts
@@ -12,6 +12,7 @@ export default defineStore({
       streamerList: [],
     },
     Volume: 1,
+    Muted: false,
     TheatreAudio: false,
   }),
   actions: {

--- a/composables/useSettingStore.ts
+++ b/composables/useSettingStore.ts
@@ -11,6 +11,8 @@ export default defineStore({
       },
       streamerList: [],
     },
+    Volume: 1,
+    TheatreAudio: false,
   }),
   actions: {
     // Action to update octoData with a new array of strings

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,12 +13,7 @@ export default defineNuxtConfig({
     '/': { prerender: true },
   },
   css: ['~/assets/css/main.css'],
-  app: {
-    head: {
-      script: [{ src: 'https://embed.twitch.tv/embed/v1.js' }],
-    },
-  },
-
+  plugins: ['~/plugins/twitch-embed.client.ts'],
   modules: [
     '@pinia/nuxt',
     '@pinia-plugin-persistedstate/nuxt',

--- a/plugins/twitch-embed.client.ts
+++ b/plugins/twitch-embed.client.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin((nuxtApp) => {
+    if (process.client) {
+        const script = document.createElement('script');
+        script.src = 'https://embed.twitch.tv/embed/v1.js';
+        document.body.appendChild(script);
+    }
+})

--- a/stores/index.ts
+++ b/stores/index.ts
@@ -29,6 +29,9 @@ export const useGlobalStateStore = defineStore('GlobalState', {
         editMode: false,
         onlineFilterSearch: false,
         offlineFilterSearch: false,
+        muted: false,
+        volume: 1,
+        theatreAudio: false,
     }),
     actions: {
         addEmbed(newString: string) {

--- a/stores/index.ts
+++ b/stores/index.ts
@@ -29,7 +29,6 @@ export const useGlobalStateStore = defineStore('GlobalState', {
         editMode: false,
         onlineFilterSearch: false,
         offlineFilterSearch: false,
-        muted: false,
         volume: 1,
         theatreAudio: false,
     }),

--- a/stores/index.ts
+++ b/stores/index.ts
@@ -30,7 +30,6 @@ export const useGlobalStateStore = defineStore('GlobalState', {
         onlineFilterSearch: false,
         offlineFilterSearch: false,
         volume: 1,
-        theatreAudio: false,
     }),
     actions: {
         addEmbed(newString: string) {
@@ -41,6 +40,10 @@ export const useGlobalStateStore = defineStore('GlobalState', {
         },
         removeEmbed(string: string) {
             this.embedsList = this.embedsList.filter((item) => item.toUpperCase() !== string.toUpperCase());
+            if (this.embedsList.length === 0 || this.expandedEmbed.includes(string)) {
+                this.isExpand = false;
+                this.expandedEmbed = '';
+            }
         },
         setOctoData(newData: string[]) {
             this.octoData = newData;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,6 +35,8 @@ declare global {
             },
             streamerList: string[],
         },
+        Volume: number,
+        TheatreAudio: boolean,
     }
 
     // Octo store state types (User saved data)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,6 +36,7 @@ declare global {
             streamerList: string[],
         },
         Volume: number,
+        Muted: boolean,
         TheatreAudio: boolean,
     }
 


### PR DESCRIPTION
- You can now globally mute/unmute all streams at once (Keyboard Shortcut: `M`)
- New Theatre Mode feature lets you have audio only from the expanded stream (Enabled by default)
- Includes some bug fixes and behaviour improvements, see previous commits for more details